### PR TITLE
fix build errors for ru images and space ids

### DIFF
--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -32,6 +32,9 @@ export function WelcomePage() {
     "!OAMvlYAJNHAeJAHqMJ:kiki-server.allstora.com": {"discussion": "!KbdMTynRVIyEstrZBb:kiki-server.allstora.com", "intro": "!neoqrlvgGuUZAZLaQD:kiki-server.allstora.com", "hostName": "Kate and Leisha"},
     "!SIvciPzZUwTOeumsjM:kiki-server.allstora.com": {"discussion": "!wsavZGmlDvFYBEomkN:kiki-server.allstora.com", "intro": "!ZSDcqngwrcRomAvAHg:kiki-server.allstora.com", "hostName": "Dylan"},
     "!gofhedAMppDZiREscQ:kiki-server.allstora.com": {"discussion": "!iKEWEyyYVAsGjSYEwq:kiki-server.allstora.com", "intro": "!bMTPoMcAggFZmReBNZ:kiki-server.allstora.com", "hostName": "Gus"},
+    "!ojBDxbTjFVezlkZecR:kiki-server.allstora.com": {"discussion": "!zZGAlAVCFiiZILPznL:kiki-server.allstora.com", "intro": "!QzrUrcYlpPdnzhOypL:kiki-server.allstora.com", "hostName": "Rob"},
+    // TODO: we may want to change these room IDs if we add the common rooms to Ru's club
+    "!cwvocyDXRTKBDZkXKb:kiki-server.allstora.com": {"discussion": "!rgHJQdtucUuLMiCpfL:kiki-server.allstora.com", "intro": "!eZcJrpjWLHDwMazhQz:kiki-server.allstora.com", "hostName": "RuPaul"}
   }
 
   return (

--- a/src/app/utils/customClubs.ts
+++ b/src/app/utils/customClubs.ts
@@ -1,17 +1,19 @@
 import { Icons, IconSrc } from 'folds';
 import { CSSProperties } from 'react';
+import RuPaulLogo from '../../../public/img/rupaul_logo.png';
+import RuPaulBackground from '../../../public/img/rupaul_background.png';
 
 export const CUSTOM_CLUBS: Record<string, CustomClub> = {
   // RuPaul's Book Club
   '!cwvocyDXRTKBDZkXKb:kiki-server.allstora.com': {
     lobbyLogo: {
-      src: '/public/img/rupaul_logo.png',
+      src: RuPaulLogo,
       alt: 'RuPaul Logo',
       invertOnDark: true,
     },
     roomIcon: Icons.Heart,
     backgroundImage: {
-      src: '/public/img/rupaul_background.png',
+      src: RuPaulBackground,
       position: 'bottom left',
       repeat: 'no-repeat',
       size: 'cover',


### PR DESCRIPTION
### Overview

This PR adds Ru's room IDs to the SPACES_MAP that controls the welcome page. It also uses the imported path instead of a relative path for the logo and bg image.