### PR TITLE
Use safe optional space hook and fix mismatched IDs

### DIFF
--- a/src/app/features/lobby/RoomItem.tsx
+++ b/src/app/features/lobby/RoomItem.tsx
@@ -41,7 +41,7 @@ import { getDirectRoomAvatarUrl, getRoomAvatarUrl } from '../../utils/room';
 import { ItemDraggableTarget, useDraggableItem } from './DnD';
 import { mxcUrlToHttp } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
-import { useSpace } from '../../hooks/useSpace';
+import { useSpaceOptionally } from '../../hooks/useSpace';
 import { CUSTOM_CLUBS } from '../../utils/customClubs';
 
 type RoomJoinButtonProps = {
@@ -207,8 +207,8 @@ function RoomProfile({
   joinRule,
   options,
 }: RoomProfileProps) {
-  const space = useSpace();
-  const customClub = space.roomId in CUSTOM_CLUBS ? CUSTOM_CLUBS[space.roomId] : undefined;
+  const space = useSpaceOptionally();
+  const customClub = space && space.roomId in CUSTOM_CLUBS ? CUSTOM_CLUBS[space.roomId] : undefined;
 
   return (
     <Box grow="Yes" gap="300">

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -39,7 +39,7 @@ import { getMatrixToRoom } from '../../plugins/matrix-to';
 import { getCanonicalAliasOrRoomId, isRoomAlias } from '../../utils/matrix';
 import { getViaServers } from '../../plugins/via-servers';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
-import { useSpace } from '../../hooks/useSpace';
+import { useSpaceOptionally } from '../../hooks/useSpace';
 import { CUSTOM_CLUBS } from '../../utils/customClubs';
 
 type RoomNavItemMenuProps = {
@@ -202,8 +202,8 @@ export function RoomNavItem({
 
   const optionsVisible = hover || !!menuAnchor;
 
-  const space = useSpace();
-  const customClub = space.roomId in CUSTOM_CLUBS ? CUSTOM_CLUBS[space.roomId] : undefined;
+  const space = useSpaceOptionally();
+  const customClub = space && space.roomId in CUSTOM_CLUBS ? CUSTOM_CLUBS[space.roomId] : undefined;
 
   return (
     <NavItem

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -28,10 +28,10 @@ export function WelcomePage() {
 
   const SPACES_MAP: {[key:string]: {[key2:string]: string}} = {
     "!PXXwRDLBXUcZVPlYjy:kiki-server.allstora.com": {"discussion": "!JvpqSiSSyYmZCgEAoY:kiki-server.allstora.com", "intro": "!wPQBycjzCRnsZjbOuS:kiki-server.allstora.com", "hostName": "Eric"},
-    "!QylPBYzSFBgSmRjpAx:kiki-server.allstora.com": {"discussion": "!JFFlUHoJYQtSqVKQxQ:kiki-server.allstora.com", "intro": "!MrneWlEWJPwrMuFkEw:kiki-server.allstora.com", "hostName": "Jordy"},
-    "!OAMvlYAJNHAeJAHqMJ:kiki-server.allstora.com": {"discussion": "!KbdMTynRVIyEstrZBb:kiki-server.allstora.com", "intro": "!neoqrlvgGuUZAZLaQD:kiki-server.allstora.com", "hostName": "Kate and Leisha"},
-    "!SIvciPzZUwTOeumsjM:kiki-server.allstora.com": {"discussion": "!wsavZGmlDvFYBEomkN:kiki-server.allstora.com", "intro": "!ZSDcqngwrcRomAvAHg:kiki-server.allstora.com", "hostName": "Dylan"},
-    "!gofhedAMppDZiREscQ:kiki-server.allstora.com": {"discussion": "!iKEWEyyYVAsGjSYEwq:kiki-server.allstora.com", "intro": "!bMTPoMcAggFZmReBNZ:kiki-server.allstora.com", "hostName": "Gus"},
+    "!QylPBYzSFBgSmRjpAx:kiki-server.allstora.com": {"discussion": "!JFFlUHoJYQtSqVKQxQ:kiki-server.allstora.com", "intro": "!JbZlMAriZObAMoZuNG:kiki-server.allstora.com", "hostName": "Jordy"},
+    "!OAMvlYAJNHAeJAHqMJ:kiki-server.allstora.com": {"discussion": "!KbdMTynRVIyEstrZBb:kiki-server.allstora.com", "intro": "!dIcqUSzSzhKQUVvATi:kiki-server.allstora.com", "hostName": "Kate and Leisha"},
+    "!SIvciPzZUwTOeumsjM:kiki-server.allstora.com": {"discussion": "!wsavZGmlDvFYBEomkN:kiki-server.allstora.com", "intro": "!gVuuVMYsHQCPdbybJS:kiki-server.allstora.com", "hostName": "Dylan"},
+    "!gofhedAMppDZiREscQ:kiki-server.allstora.com": {"discussion": "!iKEWEyyYVAsGjSYEwq:kiki-server.allstora.com", "intro": "!XUQUBThNrhfMixbWLB:kiki-server.allstora.com", "hostName": "Gus"},
     "!ojBDxbTjFVezlkZecR:kiki-server.allstora.com": {"discussion": "!zZGAlAVCFiiZILPznL:kiki-server.allstora.com", "intro": "!QzrUrcYlpPdnzhOypL:kiki-server.allstora.com", "hostName": "Rob"},
     // TODO: we may want to change these room IDs if we add the common rooms to Ru's club
     "!cwvocyDXRTKBDZkXKb:kiki-server.allstora.com": {"discussion": "!rgHJQdtucUuLMiCpfL:kiki-server.allstora.com", "intro": "!eZcJrpjWLHDwMazhQz:kiki-server.allstora.com", "hostName": "RuPaul"}


### PR DESCRIPTION
### Overview

This PR updates a few room IDs on the welcome page. I couldn't find rooms with the old IDs in cinny or the shopify webhooks scripts we use to populate the rooms with members. It also uses a safer hook that avoids the "Space not provided!" error.