### PR TITLE
fix: redirect all traffic to my.allstora.com/kiki placeholder

### DIFF
--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -1,25 +1,16 @@
 server {
-  
   add_header X-Content-Type-Options nosniff;
-  #add_header X-XSS-Protection "1; mode=block";
-  #add_header Content-Security-Policy "frame-ancestors 'self' *allstora-dev.myshopify.com *allstora.com";
-  
+
   listen 80;
   listen [::]:80;
 
   location / {
-    root /usr/share/nginx/html;
-
-    rewrite ^/config.json$ /config.json break;
-    rewrite ^/manifest.json$ /manifest.json break;
-
-    rewrite ^.*/olm.wasm$ /olm.wasm break;
-    rewrite ^/sw.js$ /sw.js break;
-    rewrite ^/pdf.worker.min.js$ /pdf.worker.min.js break;
-
-    rewrite ^/public/(.*)$ /public/$1 break;
-    rewrite ^/assets/(.*)$ /assets/$1 break;
-
-    rewrite ^(.+)$ /index.html break;
+    # ALB health checks (User-Agent contains "ELB-HealthChecker") need a
+    # 2xx response or the target gets killed. Everyone else is a real
+    # visitor — redirect to the Under Construction placeholder.
+    if ($http_user_agent ~* "ELB-HealthChecker") {
+      return 200 "ok";
+    }
+    return 301 https://my.allstora.com/kiki;
   }
 }


### PR DESCRIPTION
## Summary
Replaces the SPA-serving NGINX config in the Cinny Docker image with a `301` redirect to `https://my.allstora.com/kiki` — the new "Under Construction" placeholder.

After this lands, anyone visiting `https://kiki-chat.allstora.com/anything` is sent to the new URL automatically. Closes the loop on the storefront-side work already done in `shopqueer/allstora-clubs#72` (placeholder live) and `shopqueer/allstora-website#189` (Shopify links updated).

## Why
- The Matrix-based Kiki has been partially broken for months (member sync stopped Dec 2025, discussion posts Feb 2026).
- The Supabase-based replacement (`allstora-clubs#60`) is being built, lives at the same `my.allstora.com/kiki` URL when ready, so this redirect doesn't need to change again.
- Old emails, bookmarks, and direct links to `kiki-chat.allstora.com` should land users on the placeholder, not the broken chat.

## The change
A single-file edit to `docker-nginx.conf`:

```nginx
server {
  add_header X-Content-Type-Options nosniff;

  listen 80;
  listen [::]:80;

  location / {
    if ($http_user_agent ~* "ELB-HealthChecker") {
      return 200 "ok";
    }
    return 301 https://my.allstora.com/kiki;
  }
}
```

### Why the User-Agent guard
The ALB health-checks the target on `/` and expects a `2xx`. A blanket 301 would fail the health check, ECS would kill the task, and the deployment would loop. The `ELB-HealthChecker` User-Agent (set by AWS) gets a `200 OK`; every real visitor falls through to the 301.

## Rollout
Single pipeline (CinnyPipeline in account `381492071801`):
1. Merge to `main` → pipeline triggers (~25–40 min end-to-end).
2. Beta deploys first to `kiki-beta.allstora.com`.
3. Prod deploys after Beta succeeds, to `kiki-chat.allstora.com`.

## Smoke test (after deploy)
```bash
# Beta
curl -I https://kiki-beta.allstora.com/
# Expect: 301 / Location: https://my.allstora.com/kiki

# Prod
curl -I https://kiki-chat.allstora.com/
# Expect: 301 / Location: https://my.allstora.com/kiki
```
Also visit each in a browser and confirm landing on the Under Construction page.

## Rollback
Revert this commit on `main` → pipeline picks it up → previous Cinny app restored in ~15 min.

## Out of scope
- Tearing down the underlying Fargate/ECS/VPC resources for `cinny-chat.allstora.com`. Those keep running (serving the redirect via NGINX). Can be cost-optimized in a separate PR by replacing the Fargate service with an ALB-level redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
