### PR TITLE
fix: serve SW kill-switch so legacy Cinny clients unstick

### DIFF
--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -4,6 +4,17 @@ server {
   listen 80;
   listen [::]:80;
 
+  # Kill-switch for the legacy Cinny service worker. Browsers that
+  # previously visited kiki-chat fetch /sw.js to check for updates;
+  # we serve a tiny SW that unregisters itself and force-navigates
+  # any open tabs so they hit the 301 redirect below instead of
+  # the cached old Cinny UI.
+  location = /sw.js {
+    default_type application/javascript;
+    add_header Cache-Control "no-store";
+    return 200 "self.addEventListener('install',()=>self.skipWaiting());self.addEventListener('activate',e=>e.waitUntil((async()=>{await self.registration.unregister();const cs=await self.clients.matchAll();cs.forEach(c=>c.navigate(c.url));})()));";
+  }
+
   location / {
     # ALB health checks (User-Agent contains "ELB-HealthChecker") need a
     # 2xx response or the target gets killed. Everyone else is a real
@@ -11,6 +22,7 @@ server {
     if ($http_user_agent ~* "ELB-HealthChecker") {
       return 200 "ok";
     }
+    add_header Cache-Control "no-store";
     return 301 https://my.allstora.com/kiki;
   }
 }


### PR DESCRIPTION
## Summary
Adds a tiny self-unregistering service worker at `/sw.js` so browsers that previously visited kiki-chat (and have the legacy Cinny SW registered) are cleanly migrated off it. Also adds `Cache-Control: no-store` to the redirect so browsers stop caching it.

## Why
After `#15` shipped, the 301 redirect to `https://my.allstora.com/kiki` worked in incognito mode — but signed-in browsers still landed on the cached old Cinny login (`/login/kiki-server.allstora.com`) because their previously-registered service worker was intercepting fetches and serving the cached old SPA before our NGINX redirect ever ran.

This affects every returning Kiki user, so we need an automated cleanup — telling everyone to manually clear site data isn't realistic.

## How it works
1. Returning user opens kiki-chat (or any page in the SW's scope).
2. Browser polls `/sw.js` to check for SW updates (this happens on every navigation, reload, or after the SW's max-age).
3. Our new NGINX block serves the kill-switch SW with `Cache-Control: no-store`:
   ```js
   self.addEventListener('install', () => self.skipWaiting());
   self.addEventListener('activate', e => e.waitUntil((async () => {
     await self.registration.unregister();
     const cs = await self.clients.matchAll();
     cs.forEach(c => c.navigate(c.url));
   })()));
   ```
4. Browser installs the new SW, immediately activates it (`skipWaiting`).
5. Activation unregisters the SW and force-navigates every controlled tab to its current URL.
6. The re-navigation goes through the network (no SW left to intercept) → hits the `/` 301 → lands on the placeholder.

## What changes in `docker-nginx.conf`
Two additions, both additive:

- New `location = /sw.js` block returning the kill-switch JS (priority match, `default_type: application/javascript`, `Cache-Control: no-store`).
- `add_header Cache-Control "no-store";` on the `/` 301 response so browsers don't lock in a stale redirect once the SW is gone.

The `ELB-HealthChecker` exception remains as-is.

## Test plan
Once Beta deploys (after merge):

```bash
# 1. Health checks still pass
curl -I -H "User-Agent: ELB-HealthChecker/2.0" https://kiki-beta.allstora.com/
# expected: 200 OK

# 2. Redirect still works for normal traffic
curl -I https://kiki-beta.allstora.com/
# expected: 301, Location: https://my.allstora.com/kiki, Cache-Control: no-store

# 3. /sw.js returns the kill-switch
curl https://kiki-beta.allstora.com/sw.js
# expected body: self.addEventListener('install',()=>self.skipWaiting())...
```

In a browser that previously had the old Cinny SW registered:
- Visit `https://kiki-beta.allstora.com/` once → may still show old UI briefly while SW updates.
- Visit again (or wait ~30s) → kill-switch activates → next navigation lands on `my.allstora.com/kiki` placeholder.
- DevTools → Application → Service Workers → confirm no SW is registered for `kiki-beta.allstora.com`.

Promote to prod after Beta confirms.

## Rollback
Revert this commit → previous version (just 301 redirect, no SW) is restored. Users who already received the kill-switch SW will simply have no SW; they continue working as anonymous browsers do (no caching weirdness).

## Caveats
- An extremely persistent open tab that never navigates and survives past the 24-hour SW update window without the kill-switch reaching it could in theory stay stuck. In practice this is rare; if it ever surfaces as a real complaint we can add a more aggressive HTML+inline-script cleanup as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
