### PR TITLE
fix: add Clear-Site-Data + fix SW kill-switch ordering

### DIFF
--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -9,10 +9,16 @@ server {
   # we serve a tiny SW that unregisters itself and force-navigates
   # any open tabs so they hit the 301 redirect below instead of
   # the cached old Cinny UI.
+  #
+  # `Clear-Site-Data` flushes any HTTP cache and storage for this
+  # origin as soon as a browser receives this response — that catches
+  # users whose old SPA bundle is still cache-served (a SW
+  # unregister alone doesn't flush the HTTP cache).
   location = /sw.js {
     default_type application/javascript;
     add_header Cache-Control "no-store";
-    return 200 "self.addEventListener('install',()=>self.skipWaiting());self.addEventListener('activate',e=>e.waitUntil((async()=>{await self.registration.unregister();const cs=await self.clients.matchAll();cs.forEach(c=>c.navigate(c.url));})()));";
+    add_header Clear-Site-Data "\"cache\", \"storage\"";
+    return 200 "self.addEventListener('install',()=>self.skipWaiting());self.addEventListener('activate',e=>e.waitUntil((async()=>{const cs=await self.clients.matchAll({includeUncontrolled:true});await self.registration.unregister();cs.forEach(c=>c.navigate(c.url));})()));";
   }
 
   location / {
@@ -23,6 +29,7 @@ server {
       return 200 "ok";
     }
     add_header Cache-Control "no-store";
+    add_header Clear-Site-Data "\"cache\", \"storage\"";
     return 301 https://my.allstora.com/kiki;
   }
 }


### PR DESCRIPTION
## Summary
Removes the last "user needs to hard refresh" caveat from the Kiki retirement. Adds the `Clear-Site-Data` HTTP header to both `/sw.js` and `/` responses so the browser auto-flushes its HTTP cache + storage on the next network response for `kiki-chat.allstora.com`. Also fixes a small ordering bug in the SW kill-switch from #16.

## Why
After #15 (NGINX 301) and #16 (SW kill-switch), this exchange surfaced in testing:

> "in normal browser https://kiki-chat.allstora.com/ redirecting to https://kiki-chat.allstora.com/login/kiki-server.allstora.com but in incognito it redirecting to my.allstora.com/kiki"

The SW kill-switch correctly unregistered the legacy Cinny SW (confirmed via DevTools), but the **browser's HTTP cache** still held the old SPA bundle. Cached HTML was served instantly without ever hitting the network, so our 301 never fired. Hard refresh (`Ctrl+Shift+R`) worked, but real users won't do that.

## How `Clear-Site-Data` fixes it

When the browser receives a response with `Clear-Site-Data: "cache", "storage"` for an origin, it immediately flushes the HTTP cache + IndexedDB/localStorage for that origin. The next navigation in any tab on that origin then has nothing in cache and hits the network → gets our 301 → lands on the placeholder.

Critically, this fires on **any** network response for the origin, including the routine `/sw.js` SW-update poll that browsers do on every navigation in a SW's scope. So even users who keep tabs open trigger the cleanup the moment their browser does its routine SW poll — no user action required.

## Bug fix in the SW kill-switch

The kill-switch in #16 calls `unregister()` before `matchAll()`. After unregister, the SW loses control of its clients, so `client.navigate()` becomes a no-op. Reorder:

```js
// before
await self.registration.unregister();
const cs = await self.clients.matchAll();
cs.forEach(c => c.navigate(c.url));

// after
const cs = await self.clients.matchAll({ includeUncontrolled: true });
await self.registration.unregister();
cs.forEach(c => c.navigate(c.url));
```

Also pass `includeUncontrolled: true` so we catch tabs that aren't yet under SW control.

## Browser support
- ✅ Chrome (76+), Firefox (63+), Edge — most users.
- ⚠️ Safari — ignores `Clear-Site-Data` gracefully. Safari users still get the SW kill-switch + natural cache rollover (HTML cache TTLs expire within minutes to hours on a typical browser).

Net effect: **most users get auto-cleaned with zero action**, the rest self-recover within their first browsing session.

## Test plan

After Beta deploys:

```bash
# 1. Health check still passes
curl -I -H "User-Agent: ELB-HealthChecker/2.0" https://kiki-beta.allstora.com/
# expected: 200 OK

# 2. /sw.js carries Clear-Site-Data header
curl -I https://kiki-beta.allstora.com/sw.js
# expected: Clear-Site-Data: "cache", "storage", Cache-Control: no-store

# 3. / 301 carries Clear-Site-Data header too
curl -I https://kiki-beta.allstora.com/
# expected: 301, Location: https://my.allstora.com/kiki, Clear-Site-Data: "cache", "storage"
```

Browser test:
- Open kiki-chat in a normal browser (or beta equivalent) with cached old UI.
- Reload once.
- DevTools → Application → Storage → confirm Local/Session Storage, Cache Storage, IndexedDB are all empty.
- Reload again → land on `my.allstora.com/kiki` placeholder.

## Rollback
Revert this commit → previous (#16) behavior restored. Users would just go back to needing the natural cache rollover or a hard refresh; no breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
